### PR TITLE
Update version to 3.0.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,18 @@
 {% set name = "pydicom" %}
-{% set version = "2.4.3" %}
+{% set version = "3.0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/pydicom/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: ffb8d729fcaacf7a3aca243c69fa342305d2696ec59c1f930b2e564d4f1b5fbd
+  url: https://github.com/{{ name }}/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 848ae8e36f34750cf837e48ca5cdf6f7a472145724946d5f28f529279fe11f4e
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install --no-deps --no-deps --no-build-isolation -vv .
+  skip: True # [py<310]
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
   entry_points:
     - pydicom = pydicom.cli.main:main
 
@@ -26,15 +27,16 @@ requirements:
 
 test:
   source_files:
-    - pydicom/tests
+    - pyproject.toml
+    - tests
   imports:
-    - pydicom
+    - src.pydicom
   requires:
     - pip
     - pytest
   commands:
     - pip check
-    - pytest pydicom/tests
+    - pytest tests
 
 about:
   home: https://github.com/pydicom/pydicom

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,12 @@
 # AssertionError: Regex pattern did not match.
 # Regex: "Error deepcopying the buffered element \\(7FE0,0010\\) 'Pixel Data': cannot (.*) '_io.BufferedReader' object"
 # Input: "Error deepcopying the buffered element (7FE0,0010) 'Pixel Data': cannot pickle 'BufferedReader' instances"
-{% set skip_test = "test_deepcopy_bufferedreader_raises" %}
+{% set skip_test = "test_deepcopy_bufferedreader_raises " %}
+# raise NotImplementedError("Non-relative patterns are unsupported")
+# NotImplementedError: Non-relative patterns are unsupported
+{% set skip_test = skip_test + "or test_no_absolute_path_in_get_testdata_file " %} # [win]
+{% set skip_test = skip_test + "or test_no_absolute_path_in_get_testdata_files " %} # [win]
+
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,8 @@ test:
     - pytest
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert version('{{ name }}') == '{{ version }}'"
+    - pydicom --help
     - pytest tests -k "not ({{ skip_test }})"
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ test:
   source_files:
     - pyproject.toml
     - tests
+    - src
   imports:
     - src.pydicom
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest tests -k "not {{ skip_test }}"
+    - pytest tests -k "not ({{ skip_test }})"
 
 about:
   home: https://github.com/pydicom/pydicom

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,9 @@
 {% set name = "pydicom" %}
 {% set version = "3.0.1" %}
-
+# AssertionError: Regex pattern did not match.
+# Regex: "Error deepcopying the buffered element \\(7FE0,0010\\) 'Pixel Data': cannot (.*) '_io.BufferedReader' object"
+# Input: "Error deepcopying the buffered element (7FE0,0010) 'Pixel Data': cannot pickle 'BufferedReader' instances"
+{% set skip_test = "test_deepcopy_bufferedreader_raises" %}
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -37,7 +40,7 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest tests
+    - pytest tests -k "not {{ skip_test }}"
 
 about:
   home: https://github.com/pydicom/pydicom


### PR DESCRIPTION
pydicom 3.0.1 

**Destination channel:** Defaults

### Links

- [PKG-8449](https://anaconda.atlassian.net/browse/PKG-8449)
- dev_url:        https://github.com/pydicom/pydicom/tree/v3.0.1
- conda_forge:    https://github.com/conda-forge/pydicom-feedstock
- pypi:           https://pypi.org/project/pydicom/3.0.1
- pypi inspector: https://inspector.pypi.io/project/pydicom/3.0.1

### Explanation of changes:

- new version number


[PKG-8449]: https://anaconda.atlassian.net/browse/PKG-8449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ